### PR TITLE
display fullwidth characters in report

### DIFF
--- a/src/report-template.html
+++ b/src/report-template.html
@@ -9,6 +9,7 @@
         <link rel="mask-icon" href="https://smashtest.io/favicons/safari-pinned-tab.svg" color="#5bbad5">
         <meta name="msapplication-TileColor" content="#da532c">
         <meta name="theme-color" content="#ffffff">
+        <meta charset="utf-8">
 
         <script src="https://unpkg.com/popper.js@1"></script>
         <script src="https://unpkg.com/tippy.js@4"></script>


### PR DESCRIPTION
### changes
add `charset=utf-8` in src/report-template.html
to display fullwidth characters.