### PR TITLE
Fix bug in reading capabilities variable

### DIFF
--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -136,7 +136,7 @@ class BrowserInstance {
         // Capabilities
         if(!params.capabilities) {
             try {
-                this.runInstance.findVarValue("browser capabilities", false, true); // look for {browser capabilities}, above or below
+                params.capabilities = this.runInstance.findVarValue("browser capabilities", false, true); // look for {browser capabilities}, above or below
             }
             catch(e) {}
         }


### PR DESCRIPTION
I was having trouble working out how to set capabilities for Browserstack. It seems that while you're reading the "browser capabilities" variable, you're not actually then using it. With this fix I can get it to work with something like this:

```smash
* Set capabilities {
    setGlobal("browser capabilities", {
        'browserName' : 'android',
        'device' : 'Samsung Galaxy S8',
        'realMobile' : 'true',
        'os_version' : '7.0',
        'browserstack.user' : 'myuser',
        'browserstack.key' : 'mykey',
        'name' : 'Bstack-[Node] Sample Test'
    })
}

Set capabilities

    Open Chrome

        Navigate to 'google.com'

            Type 'hello world[enter]' into 'input[name=q]'
```
Is this the "correct" way? It would be good if this was documented.