### PR TITLE
Use Jimp instead of Sharp for image manipulation

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "selenium-webdriver": "^4.0.0-alpha.1",
-    "sharp": "^0.22.1",
+    "jimp": "^0.6.4",
     "ws": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -7,7 +7,7 @@ const edge = require('selenium-webdriver/edge');
 const fs = require('fs');
 const path = require('path');
 const readFiles = require('read-files-promise');
-const sharp = require('sharp');
+const Jimp = require('jimp');
 const request = require('request-promise-native');
 const utils = require('../../src/utils.js');
 const ElementFinder = require('./elementfinder.js');
@@ -454,12 +454,10 @@ class BrowserInstance {
         // Write screenshot to file
         let filename = `screenshots/${this.runInstance.currBranch.hash}_${this.runInstance.currBranch.steps.indexOf(this.runInstance.currStep) || `0`}_${isAfter ? `after` : `before`}.jpg`;
         const SCREENSHOT_WIDTH = 1000;
-        await sharp(Buffer.from(data, 'base64'))
-            .resize(SCREENSHOT_WIDTH)
-            .jpeg({
-                quality: 50
-            })
-            .toFile(`smashtest/${filename}`);
+        (await Jimp.read(Buffer.from(data, 'base64')))
+            .resize(SCREENSHOT_WIDTH, Jimp.AUTO)
+            .quality(60)
+            .write(`smashtest/${filename}`);
 
         // Include crosshairs in report
         if(targetCoords) {


### PR DESCRIPTION
This will save us a binary download during Smashtest install (initiated by the Sharp package), which eventually prevents Smashtest to be onboarded in secured enterprise environments. I increased the quality from 50 to 60 as well, because jpeg artifacts were too much noticeable for me, and 60 is just a default number in Jimp's example code, so I just left that as it is. Please feel free to bring it back to 50, don't make it a blocker for the lib change.