### PR TITLE
Add step to compare current page to a regex

### DIFF
--- a/packages/browser.smash
+++ b/packages/browser.smash
@@ -495,6 +495,10 @@
         await browser.verifyAtPage(titleOrUrl, VERIFY_TIMEOUT);
     }
 
+    * Verify page is like {{regex}} {
+        await browser.verifyAtPageRegex(regex, VERIFY_TIMEOUT);
+    }
+
     * Verify cookie {{name}} contains {{value}} {
         await browser.verifyCookieContains(name, value, VERIFY_TIMEOUT);
     }

--- a/packages/browser.smash
+++ b/packages/browser.smash
@@ -495,7 +495,7 @@
         await browser.verifyAtPage(titleOrUrl, VERIFY_TIMEOUT);
     }
 
-    * Verify page is like {{regex}} {
+    * Verify at page like {{regex}} {
         await browser.verifyAtPageRegex(regex, VERIFY_TIMEOUT);
     }
 

--- a/packages/browser.smash
+++ b/packages/browser.smash
@@ -495,10 +495,6 @@
         await browser.verifyAtPage(titleOrUrl, VERIFY_TIMEOUT);
     }
 
-    * Verify at page like {{regex}} {
-        await browser.verifyAtPageRegex(regex, VERIFY_TIMEOUT);
-    }
-
     * Verify cookie {{name}} contains {{value}} {
         await browser.verifyCookieContains(name, value, VERIFY_TIMEOUT);
     }

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -726,9 +726,9 @@ class BrowserInstance {
             await this.driver.wait(async () => {
                 obj = await this.executeScript(function(titleOrUrl) {
                     let isMatched = document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1;
-                    let documentMatch = document.title.match(titleOrUrl);
-                    let locationMatch = window.location.href.match(titleOrUrl);
-                    isMatched = isMatched || documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href;
+                    let titleRegexMatch = document.title.match(titleOrUrl);
+                    let urlRegexMatch = window.location.href.match(titleOrUrl);
+                    isMatched = isMatched || (titleRegexMatch && titleRegexMatch[0] === document.title) || (urlRegexMatch && urlRegexMatch[0] === window.location.href);
                     return {
                         isMatched,
                         title: document.title,

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -725,7 +725,7 @@ class BrowserInstance {
         try {
             await this.driver.wait(async () => {
                 obj = await this.executeScript(function(titleOrUrl) {
-                    let isMatched: document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1;
+                    let isMatched = document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1;
                     let documentMatch = document.title.match(regex);
                     let locationMatch = window.location.href.match(regex);
                     isMatched = isMatched || documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href;

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -744,6 +744,32 @@ class BrowserInstance {
         }
     }
 
+    async verifyAtPageRegex(regex, timeout) {
+        let obj = null;
+        try {
+            await this.driver.wait(async () => {
+                obj = await this.executeScript(function(regex) {
+                    let documentMatch = document.title.match(regex);
+                    let locationMatch = window.location.href.match(regex);
+                    return {
+                        isMatched: documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href,
+                        title: document.title,
+                        url: window.location.href
+                    }
+                }, regex);
+                return obj.isMatched;
+            }, timeout)
+        }
+        catch (e) {
+            if(e.message.includes('Wait timed out after')) {
+                throw new Error(`Neither the page title ('${obj.title}'), nor the page url ('${obj.url}'), match '${regex}' after ${timeout/1000} s, ${obj.match}`);
+            }
+            else {
+                throw e;
+            }
+        }
+    }
+
     /**
      * Throws error if cookie with the given name doesn't contain the given value within timeout ms
      */

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -726,8 +726,8 @@ class BrowserInstance {
             await this.driver.wait(async () => {
                 obj = await this.executeScript(function(titleOrUrl) {
                     let isMatched = document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1;
-                    let documentMatch = document.title.match(regex);
-                    let locationMatch = window.location.href.match(regex);
+                    let documentMatch = document.title.match(titleOrUrl);
+                    let locationMatch = window.location.href.match(titleOrUrl);
                     isMatched = isMatched || documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href;
                     return {
                         isMatched,

--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -725,8 +725,12 @@ class BrowserInstance {
         try {
             await this.driver.wait(async () => {
                 obj = await this.executeScript(function(titleOrUrl) {
+                    let isMatched: document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1;
+                    let documentMatch = document.title.match(regex);
+                    let locationMatch = window.location.href.match(regex);
+                    isMatched = isMatched || documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href;
                     return {
-                        isMatched: document.title.toLowerCase().indexOf(titleOrUrl.toLowerCase()) != -1 || window.location.href.indexOf(titleOrUrl) != -1,
+                        isMatched,
                         title: document.title,
                         url: window.location.href
                     };
@@ -737,32 +741,6 @@ class BrowserInstance {
         catch(e) {
             if(e.message.includes('Wait timed out after')) {
                 throw new Error(`Neither the page title ('${obj.title}'), nor the page url ('${obj.url}'), contains '${titleOrUrl}' after ${timeout/1000} s`);
-            }
-            else {
-                throw e;
-            }
-        }
-    }
-
-    async verifyAtPageRegex(regex, timeout) {
-        let obj = null;
-        try {
-            await this.driver.wait(async () => {
-                obj = await this.executeScript(function(regex) {
-                    let documentMatch = document.title.match(regex);
-                    let locationMatch = window.location.href.match(regex);
-                    return {
-                        isMatched: documentMatch && documentMatch[0] === document.title || locationMatch && locationMatch[0] === window.location.href,
-                        title: document.title,
-                        url: window.location.href
-                    }
-                }, regex);
-                return obj.isMatched;
-            }, timeout)
-        }
-        catch (e) {
-            if(e.message.includes('Wait timed out after')) {
-                throw new Error(`Neither the page title ('${obj.title}'), nor the page url ('${obj.url}'), match '${regex}' after ${timeout/1000} s, ${obj.match}`);
             }
             else {
                 throw e;

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -1233,7 +1233,20 @@ Open test page [
                 Wait until at page 'd{3}'
                     - Verify error $s #manual
 
+        - Wait until at page (up to n secs)
 
+            - and the title contains the given text
+
+                Wait until at page 'title here' (up to '5' secs)
+
+            - and the url contains the given text
+
+                Wait until at page 'generic-page' (up to '5' secs)
+
+            - and neither the title nor the url contain the given text
+
+                Wait until at page 'badstr' (up to '5' secs)
+                    - Verify error $s #manual
 
         - Wait until at page (up to n secs) (with regex)
 

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -1129,19 +1129,19 @@ Open test page [
                 Verify at page 'badstr'
                     - Verify error $s #manual
 
-        - Verify page is like
+        - Verify at page like
 
             - and the title matches the given regex
 
-                Verify page is like 'title .*'
+                Verify at page like 'title .*'
 
             - and the url matches the given regex
 
-                Verify page is like 'generic-.*'
+                Verify at page like 'generic-.*'
 
             - and neither the title not the url matches
 
-                Verify at page '\d{3}'
+                Verify at page like '\d{3}'
                     - Verify error $s #manual
 
         - Verify cookie contains

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -1129,6 +1129,21 @@ Open test page [
                 Verify at page 'badstr'
                     - Verify error $s #manual
 
+        - Verify page is like
+
+            - and the title matches the given regex
+
+                Verify page is like 'title .*'
+
+            - and the url matches the given regex
+
+                Verify page is like 'generic-.*'
+
+            - and neither the title not the url matches
+
+                Verify at page '\d{3}'
+                    - Verify error $s #manual
+
         - Verify cookie contains
 
             - where the cookie with the given name

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -1129,19 +1129,19 @@ Open test page [
                 Verify at page 'badstr'
                     - Verify error $s #manual
 
-        - Verify at page like
+        - Verify at page (with regex)
 
             - and the title matches the given regex
 
-                Verify at page like 'title .*'
+                Verify at page 'title .*'
 
             - and the url matches the given regex
 
-                Verify at page like 'generic-.*'
+                Verify at page 'generic-.*'
 
             - and neither the title not the url matches
 
-                Verify at page like '\d{3}'
+                Verify at page 'a{3}'
                     - Verify error $s #manual
 
         - Verify cookie contains
@@ -1218,19 +1218,36 @@ Open test page [
                 Wait until at page 'badstr'
                     - Verify error $s #manual
 
-        - Wait until at page (up to n secs)
+        - Wait until at page (with regex)
 
             - and the title contains the given text
 
-                Wait until at page 'title here' (up to '5' secs)
+                Wait until at page 'title .*'
 
             - and the url contains the given text
 
-                Wait until at page 'generic-page' (up to '5' secs)
+                Wait until at page 'generic-.*'
 
             - and neither the title nor the url contain the given text
 
-                Wait until at page 'badstr' (up to '5' secs)
+                Wait until at page 'd{3}'
+                    - Verify error $s #manual
+
+
+
+        - Wait until at page (up to n secs) (with regex)
+
+            - and the title contains the given text
+
+                Wait until at page 'title .*' (up to '5' secs)
+
+            - and the url contains the given text
+
+                Wait until at page 'generic-.*' (up to '5' secs)
+
+            - and neither the title nor the url contain the given text
+
+                Wait until at page 'd{3}' (up to '5' secs)
                     - Verify error $s #manual
 
         - Wait until cookie contains


### PR DESCRIPTION
Here is a proposal for a new builtin step that checks the page relative to a given regex.

The idea is that sometimes some parameters are located in the path of a page, such as an ID (`/user/123/profile`). In those cases, using a regex is much easier than trying to assert the exact value of those IDs, especially if the ID is random.

Adding a step `Verify page is like {{regex}}` will help in those cases.

**Changes**
Added `verifyAtPageRegex` function in `packages/js/browserinstance.js` that does the match against the given regex.
Added `Verify page is like {{regex}}` step in `packages/browser.smash`
Added tests in `tests/packages/browser.smash`