### PR TITLE
Proposal: don't count disabled elements as clickable

### DIFF
--- a/packages/js/elementfinder.js
+++ b/packages/js/elementfinder.js
@@ -995,14 +995,15 @@ class ElementFinder {
                 function(elems, input) {
                     return elems.filter(function(elem) {
                         let tagName = elem.tagName.toLowerCase();
-                        return tagName == 'a' ||
+                        return (tagName == 'a' ||
                             tagName == 'button' ||
                             tagName == 'label' ||
                             tagName == 'input' ||
                             tagName == 'textarea' ||
                             tagName == 'select' ||
                             tagName == 'option' ||
-                            window.getComputedStyle(elem).getPropertyValue('cursor') == 'pointer';
+                            window.getComputedStyle(elem).getPropertyValue('cursor') == 'pointer')
+                            && !elem.disabled;
                             // TODO: handle cursor:pointer when hovered over
                     });
                 }

--- a/tests/packages/elementfinder.smash
+++ b/tests/packages/elementfinder.smash
@@ -4249,13 +4249,13 @@ open edge
                         |1+ x clickable  \u001b[0m\u001b[31m-->  not found (zero matches after \`clickable\` applied)\u001b[0m\u001b[30m`));
                 }
 
-                finds elements but skips disabled elements {
+                finds elements but skips disabled elements #breh {
                     await setPageBody(`
                         <div id="one" class="big">foobar</div>
                         <div id="two" class="big" style="cursor:pointer">foobar</div>
                         <a id="three" href="/">Link</a>
                         <button id="four">Button</button>
-                        <input id="five" disabled" />
+                        <input id="five" disabled />
                     `);
 
                     let ef = new ElementFinder(`1+ x clickable`);
@@ -4263,7 +4263,7 @@ open edge
 
                     expect(results).to.have.lengthOf(3);
                     expect(await results[0].getAttribute('id')).to.equal('two');
-                    expect(await results[2].getAttribute('id')).to.equal('four');
+                    expect(await results[1].getAttribute('id')).to.equal('three');
                     expect(await results[2].getAttribute('id')).to.equal('four');
                 }
 

--- a/tests/packages/elementfinder.smash
+++ b/tests/packages/elementfinder.smash
@@ -4249,6 +4249,24 @@ open edge
                         |1+ x clickable  \u001b[0m\u001b[31m-->  not found (zero matches after \`clickable\` applied)\u001b[0m\u001b[30m`));
                 }
 
+                finds elements but skips disabled elements {
+                    await setPageBody(`
+                        <div id="one" class="big">foobar</div>
+                        <div id="two" class="big" style="cursor:pointer">foobar</div>
+                        <a id="three" href="/">Link</a>
+                        <button id="four">Button</button>
+                        <input id="five" disabled" />
+                    `);
+
+                    let ef = new ElementFinder(`1+ x clickable`);
+                    let results = await ef.find(browser.driver, undefined, false, false, 500);
+
+                    expect(results).to.have.lengthOf(3);
+                    expect(await results[0].getAttribute('id')).to.equal('two');
+                    expect(await results[2].getAttribute('id')).to.equal('four');
+                    expect(await results[2].getAttribute('id')).to.equal('four');
+                }
+
             - page title
 
                 set page title {

--- a/tests/packages/elementfinder.smash
+++ b/tests/packages/elementfinder.smash
@@ -4249,7 +4249,7 @@ open edge
                         |1+ x clickable  \u001b[0m\u001b[31m-->  not found (zero matches after \`clickable\` applied)\u001b[0m\u001b[30m`));
                 }
 
-                finds elements but skips disabled elements #breh {
+                finds elements but skips disabled elements {
                     await setPageBody(`
                         <div id="one" class="big">foobar</div>
                         <div id="two" class="big" style="cursor:pointer">foobar</div>


### PR DESCRIPTION
Today while writing some tests I assumed that searching for 'clickable' elements wouldn't return disabled inputs, textareas, etc. However, it does.

That's why I propose this small change to the behavior of the 'clickable' elementfinder prop.

Changes:
- added a `!disabled` condition to `elementfinder.js`
- added a test to `elementfinder.smash`

