### PR TITLE
Add ability to run smash files in subdirectories

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -218,6 +218,11 @@ Options
                 runner.random = boolValue();
                 break;
 
+            case "recursive":
+                noValue();
+                isRecursive = true;
+                break;
+
             case "repl":
             case "r":
                 noValue();
@@ -276,11 +281,6 @@ Options
                     utils.error(`Invalid test-server. It must be in the format 'http://...' or 'https://...'.`);
                 }
                 runner.testServer = value;
-                break;
-            
-            case "recursive":
-                noValue();
-                isRecursive = true;
                 break;
 
             case "version":

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,7 @@ const Constants = require('./constants.js');
 // ***************************************
 
 let isReport = true;
+let isRecursive = false;
 
 const yellowChalk = chalk.hex("#ffb347");
 const hRule = chalk.gray("─".repeat(process.stdout.columns));
@@ -279,7 +280,7 @@ Options
             
             case "recursive":
                 noValue();
-                runner.isRecursive = true;
+                isRecursive = true;
                 break;
 
             case "version":
@@ -404,7 +405,7 @@ function plural(count) {
         if(filenames.length == 0 && !runner.isRepl) {
             let searchString = '*.smash';
 
-            if (runner.isRecursive) {
+            if (isRecursive) {
                 searchString = '**/*.smash';
             }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -163,6 +163,7 @@ Options
   --output-errors=<true/false>             Whether to output all errors to console
   --p:<name>="<value>"                     Set a persistent variable
   --random=<true/false>                    Whether to randomize the order of branches
+  --recursive                              Scan the current directory and subdirectories for .smash files
   --repl                                   Open the REPL (drive Smashtest from command line) (-r)
   --report-domain=<domain>                 Domain and port where report server should run (domain or domain:port format)
   --report-history=<true/false>            Whether to keep a history of all reports by date
@@ -173,7 +174,6 @@ Options
   --step-data=<all/fail/none>              Keep step data for all steps, only failed steps, or no steps
   --test-server=<url>                      Location of test server (e.g., http://localhost:4444/wd/hub for selenium server)
   --version                                Output the version of Smashtest (-v)
-  --recursive                              Scan the current directory and subdirectories for .smash files
 `);
                 process.exit();
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -173,6 +173,7 @@ Options
   --step-data=<all/fail/none>              Keep step data for all steps, only failed steps, or no steps
   --test-server=<url>                      Location of test server (e.g., http://localhost:4444/wd/hub for selenium server)
   --version                                Output the version of Smashtest (-v)
+  --recursive                              Scan the current directory and subdirectories for .smash files
 `);
                 process.exit();
 
@@ -274,6 +275,11 @@ Options
                     utils.error(`Invalid test-server. It must be in the format 'http://...' or 'https://...'.`);
                 }
                 runner.testServer = value;
+                break;
+            
+            case "recursive":
+                noValue();
+                runner.isRecursive = true;
                 break;
 
             case "version":
@@ -396,9 +402,15 @@ function plural(count) {
         }
 
         if(filenames.length == 0 && !runner.isRepl) {
+            let searchString = '*.smash';
+
+            if (runner.isRecursive) {
+                searchString = '**/*.smash';
+            }
+
             let smashFiles = await new Promise((resolve, reject) => {
                 // if no filenames passed in, just choose all the .smash files
-                glob('*.smash', {absolute: true}, (err, smashFiles) => err ? reject(err) : resolve(smashFiles));
+                glob(searchString, {absolute: true}, (err, smashFiles) => err ? reject(err) : resolve(smashFiles));
             });
 
             if(!smashFiles) {


### PR DESCRIPTION
Guys here is a little update that allows you to pass --recursive to the cli, then if there have been no files passed in the glob search string is changed from '*.smash' to '**/*.smash' which scans the current directory and all subdirectories for .smash files.

This allows me to be able to organize my files into directories.