### PR TITLE
Fix issue ECONNREFUSED when parallel.

### DIFF
--- a/packages/js/browserinstance.js
+++ b/packages/js/browserinstance.js
@@ -264,7 +264,7 @@ class BrowserInstance {
     async close() {
         try {
             if(this.driver) {
-                await this.driver.quit();
+                await this.driver.close();
                 this.driver = null;
             }
         }

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -915,8 +915,9 @@ Open test page [
             }
 
                 Switch to iframe [#frame]
-                    Verify ['Example Domain'] is visible
-                        Verify ['foobar'] is not visible
+                    Wait '2' secs
+                        Verify ['Example Domain'] is visible
+                            Verify ['foobar'] is not visible
 
         - Switch to topmost iframe
 


### PR DESCRIPTION
This fixes an issue that was preventing me from being able to run tests in parallel. I think that .quit was trying to kill the other browsers that were still open, I think that it is .close that you want here. This update allowed me to run in parallel and killAllBrowsers(runner) will take care of the .quit when all tests are done.