### PR TITLE
Docker commands fail due to non-compliant project naming

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,21 +1,21 @@
 up: ## Spin up the container
-	docker-compose -p SmashTest up -d
+	docker-compose -p smashtest up -d
 	docker ps -a
 
 stop: ## Stop running containers
-	docker-compose -p SmashTest stop
+	docker-compose -p smashtest stop
 
 kill: ## Stop and remove all containers
-	docker-compose -p SmashTest down
+	docker-compose -p smashtest down
 
 build: ## Rebuild the image
 	docker image build -t smashtestio .
 
 get_key: up ## Copy out the private key
-	docker cp $(shell docker-compose -p SmashTest ps -q):/home/smashtest/.ssh/id_ecdsa ./docker-private-key-id_ecdsa
+	docker cp $(shell docker-compose -p smashtest ps -q):/home/smashtest/.ssh/id_ecdsa ./docker-private-key-id_ecdsa
 
 shell: up ## Start the container with a command prompt
-	docker exec -it $(shell docker-compose -p SmashTest ps -q) bash
+	docker exec -it $(shell docker-compose -p smashtest ps -q) bash
 
 devel: ## Start up a new container from the image and open a shell
 	docker run --entrypoint bash -it smashtestio

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.0'
 
 services:
 
-  SmashTest:
+  smashtest:
     image: smashtestio
 
     ports: 


### PR DESCRIPTION
Docker services can't have uppercase letters in newer versions. 'SmashTest' is not compliant with this requirement. This pull request changes the words SmashTest to smashtest to fix the problem.