### PR TITLE
Improve text-based element finder to cover SVG elements

### DIFF
--- a/packages/js/elementfinder.js
+++ b/packages/js/elementfinder.js
@@ -1301,9 +1301,12 @@ class ElementFinder {
             'innertext': [
                 function(elems, input) {
                     return elems.filter(function(elem) {
+                        let text = elem.innerText;
                         // SVG elements have undefined .innerText, so we fall back to
                         // .textContent in that case
-                        let text = elem.innerText ?? elem.textContent;
+                        if (typeof text == 'undefined') {
+                            text = elem.textContent;
+                        }
                         return (text || '').indexOf(input) != -1;
                     });
                 }

--- a/packages/js/elementfinder.js
+++ b/packages/js/elementfinder.js
@@ -1301,7 +1301,10 @@ class ElementFinder {
             'innertext': [
                 function(elems, input) {
                     return elems.filter(function(elem) {
-                        return (elem.innerText || '').indexOf(input) != -1;
+                        // SVG elements have undefined .innerText, so we fall back to
+                        // .textContent in that case
+                        let text = elem.innerText ?? elem.textContent;
+                        return (text || '').indexOf(input) != -1;
                     });
                 }
             ],


### PR DESCRIPTION
The "innertext" filter in elementfinder is based on elem.innerText, but SVG elements have no `.innerText` property, only `.textContent`. Now `.textContent` behaves differently on HTML nodes, and this modification doesn't want to introduce any breaking changes. It only "feature detects" `.innerText`, and if it's undefined, it falls back to `.textContent`. (`.innerText` is never undefined on HTML nodes.) The motivation of this PR comes from my experience not being able to click on highcharts chart slices, because of the aforementioned issue.