### PR TITLE
Add click and type steps with no target element

### DIFF
--- a/src/packages/browser.smash
+++ b/src/packages/browser.smash
@@ -126,6 +126,10 @@
         await browser.nav(url);
     }
 
+    * Click {
+        await browser.driver.actions({ bridge: true }).click().perform()
+    }
+
     * Click {{element}} {
         let elem = await $(element, true);
         if(browser.params.name === 'safari') {
@@ -179,6 +183,10 @@
             await browser.driver.actions({bridge: true}).move({origin: elem}).perform();
         }
     }
+
+    * Hover over and click {{element}} ..
+        Hover over {{element}}
+        Click
 
     * Scroll to {{element}} {
         await executeScript(function(element) {
@@ -244,6 +252,15 @@
         }
 
         await browser.type(text, element);
+    }
+
+    * Type {{text}} {
+        if(text.trim().toLowerCase() == '[none]') {
+            log(`Ignoring since text is set to [none]`);
+            return;
+        }
+
+        await browser.type(text);
     }
 
     * Clear {{element}} {

--- a/src/packages/js/browserinstance.ts
+++ b/src/packages/js/browserinstance.ts
@@ -360,7 +360,7 @@ class BrowserInstance {
      * @param {String} text - The text to type in
      * @param {String, ElementFinder, or WebElement} element - The element to type into (same as the element sent to $())
      */
-    async type(text: string, element: EFElement) {
+    async type(text: string, element?: EFElement) {
         let items = text.split(/(?=(?<=[^\\])\[)|(?<=(?=[^\\])\])/g);
         items = items.map((item) => {
             const keyName = item.match(/^\[(?<keyName>.*)\]$/)?.groups?.keyName?.toUpperCase();
@@ -379,7 +379,13 @@ class BrowserInstance {
             }
         });
 
-        await (await this.$(element)).sendKeys(...items);
+        if (element) {
+            await (await this.$(element)).sendKeys(...items);
+        }
+        else {
+            invariant(this.driver, 'Missing driver instance in type()');
+            await this.driver.actions({ bridge: true }).sendKeys(items.join('')).perform();
+        }
     }
 
     /**

--- a/tests/packages/browser.smash
+++ b/tests/packages/browser.smash
@@ -70,6 +70,20 @@ Open test page
 
                         Verify ['I was clicked'] is visible
 
+                    - with an API using no target element
+
+                        Hover over [target button]
+
+                            Click
+
+                                Verify ['I was clicked'] is visible
+
+                    - with an API using no target element 2
+
+                        Hover over and click [target button]
+
+                            Verify ['I was clicked'] is visible
+
             - an unclickable child of a clickable parent
 
                 Generate page {
@@ -416,6 +430,12 @@ Open test page
 
                     Type 'foobar' into [#textbox]
                         Verify 'foobar' is typed in
+
+                - a normal string of chars into a textbox - with an API using no target element
+
+                    Click [#textbox]
+                        Type 'foobar'
+                            Verify 'foobar' is typed in
 
                 - '[none]'
 


### PR DESCRIPTION
This PR aims to add 3 new steps as primitives for targetless input click and type actions. The steps are these:

- _Click_
- _Hover over and click {{element}}_
- _Type {{text}}_

Currently Smashtest provides

- _Click {{element}}_
- _Type {{text}} into {{element}}_

The problem with these steps is that they're bound to an elementfinder, which might not be accessible. I will go through each new step to give a justification.

## `Hover over and click {{element}}`

A real-world example I had is an Highcharts pie chart. I wanted to click on a slice of the pie chart, but I had no meaningful elementfinder for the slice. However, I had labels over the slices, which could serve as meaningful elementfinder targets, but those labels had no DOM connection to the underlying slice, it was just absolutely positioned, so clicking on them with the current API didn't trigger the slice's onClick action (which performs a filtering). Separating `Click {{element}}` into 2 steps: hovering over the label, and performing a targetless click solved the issue. It involves a different webdriver API. This way of clicking is actually more close to simulating the real world, and it can be used as a generic method. It is similar to Cypress's _elem.click({ force: true })_ method.

## `Click`

I didn't have a real-world use case for this per se, but it make sense to provide it as a primitve building block for the previous one, if only because of code structuring purposes. I can imagine use cases of where moving the mouse and clicking are loosely connected (e.g. games).

## `Type {{text}}`

The motivation is similar to the previous ones. The real-world example I had was automating login on webpages with buggy implementations, where the input elements don't have a proper label (typical error is messing up the for/name/id attribs). In this case, a natural workaround is, again, moving closer to the real world actions: typing and tabbing through the input elements"

```
Click ['User name']
Type {{username}}
Type '[TAB]'
Type {{password}}
Type '[ENTER]'
```

This example also demonstrates why this method can't really be kept in user space, as the special key replacement is done in browserinstance.ts.

